### PR TITLE
Create release workflow in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Create Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build & Package
+    runs-on: macos-14
+    
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Select Xcode
+        run: sudo xcode-select -s /Applications/Xcode_15.4.app
+
+      - name: Build and Package
+        run: |
+          chmod +x scripts/build_release.sh
+          ./scripts/build_release.sh
+        env:
+          CODE_SIGNING_ALLOWED: NO
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: ClockSpace.dmg
+          body: |
+            ## ClockSpace Release ${{ github.ref_name }}
+            
+            **Note**: This build is unsigned. Right-click and select "Open" to launch.
+          draft: false
+          prerelease: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add GitHub Actions workflow for creating releases on tag push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated release workflow that triggers on version tag pushes, building the application and publishing releases to GitHub with generated artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->